### PR TITLE
Clean up use of closure property wrappers

### DIFF
--- a/Sources/WebIDLToSwift/IDLBuilder.swift
+++ b/Sources/WebIDLToSwift/IDLBuilder.swift
@@ -2,7 +2,7 @@ import Foundation
 import WebIDL
 
 enum IDLBuilder {
-    static let basicDependencies = ["ECMAScript", "JavaScriptKit", "JavaScriptEventLoop"]
+    static let basicDependencies = ["ECMAScript", "JavaScriptKit"]
     static let optionalDependencies = ["JavaScriptEventLoop"]
 
     static let preamble = """
@@ -95,9 +95,8 @@ enum IDLBuilder {
     }
 
     static func generateClosureTypes() throws -> SwiftSource {
-        print("Generating closure property wrappers...")
+        print("Generating closure wrappers...")
         return """
-        /* variadic generics please */
         \(lines: ModuleState.closurePatterns.sorted().map(\.swiftRepresentation))
         """
     }

--- a/Sources/WebIDLToSwift/MergeDeclarations.swift
+++ b/Sources/WebIDLToSwift/MergeDeclarations.swift
@@ -7,9 +7,6 @@ enum DeclarationMerger {
         "CustomElementConstructor",
         "ArrayBufferView",
         "RotationMatrixType",
-        // Mapped to `Int32` manually. This can't be represented as `Int64` due to `BigInt` representation on JS side,
-        // but as a pointer it can't be represented as floating point number either.
-        "GLintptr",
     ]
     static let ignoredIncludeTargets: Set<String> = ["WorkerNavigator"]
     static let validExposures: Set<String> = ["Window"]


### PR DESCRIPTION
This changes improves compatibility of the WebAPIKit library with Embedded Swift. Unsupported concurrency code is excluded when concurrency is not available, including the use of async sequences. Use of closure patterns is cleaned up to use getters and setters directly instead of property wrappers, which reduces binary code size when Embedded Swift is used.